### PR TITLE
각 View 사이의 NavigationLink 연결 및 기타 오류수정

### DIFF
--- a/Noo6Main.xcodeproj/project.pbxproj
+++ b/Noo6Main.xcodeproj/project.pbxproj
@@ -72,21 +72,17 @@
 			isa = PBXGroup;
 			children = (
 				7953082E27FD7E78000D40DB /* Noo6MainApp.swift */,
-				D42F483727FED4C9009FECA0 /* CategoryView.swift */,
 				552605BF28005F630028C141 /* HomeView.swift */,
-				E901BB9428006550003AF610 /* HonorView.swift */,
-				552605BB27FED8EE0028C141 /* CategoryRow.swift */,
 				552605BD27FF17FE0028C141 /* CategoryList.swift */,
-
+				552605BB27FED8EE0028C141 /* CategoryRow.swift */,
+				D42F483727FED4C9009FECA0 /* CategoryView.swift */,
 				BF2CEDF928006ECB003401D6 /* GuideView.swift */,
 				BF2CEDFB28006F08003401D6 /* ImageView.swift */,
 				BF2CEDFF28006FB1003401D6 /* Bottom.swift */,
-
 				79373AFE28006D7400CDAD04 /* ClearView.swift */,
-
-				E901BB9728006915003AF610 /* HonorDetailView.swift */,
+				E901BB9428006550003AF610 /* HonorView.swift */,
 				E901BB9628006915003AF610 /* LinkView.swift */,
-
+				E901BB9728006915003AF610 /* HonorDetailView.swift */,
 				7953083227FD7E79000D40DB /* Assets.xcassets */,
 				7953083427FD7E79000D40DB /* Preview Content */,
 			);
@@ -177,9 +173,7 @@
 				552605BC27FED8EE0028C141 /* CategoryRow.swift in Sources */,
 				7953082F27FD7E78000D40DB /* Noo6MainApp.swift in Sources */,
 				552605C028005F630028C141 /* HomeView.swift in Sources */,
-
 				BF2CEDFA28006ECB003401D6 /* GuideView.swift in Sources */,
-
 				E901BB9928006915003AF610 /* HonorDetailView.swift in Sources */,
 				552605BE27FF17FE0028C141 /* CategoryList.swift in Sources */,
 				E901BB9828006915003AF610 /* LinkView.swift in Sources */,

--- a/Noo6Main.xcodeproj/project.pbxproj
+++ b/Noo6Main.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		7953083327FD7E79000D40DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7953083227FD7E79000D40DB /* Assets.xcassets */; };
 		7953083627FD7E79000D40DB /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7953083527FD7E79000D40DB /* Preview Assets.xcassets */; };
 		BF2CEDFA28006ECB003401D6 /* GuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2CEDF928006ECB003401D6 /* GuideView.swift */; };
-		BF2CEDFC28006F08003401D6 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2CEDFB28006F08003401D6 /* ImageView.swift */; };
+		BF2CEDFC28006F08003401D6 /* GuideImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2CEDFB28006F08003401D6 /* GuideImageView.swift */; };
 		BF2CEE0028006FB1003401D6 /* Bottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2CEDFF28006FB1003401D6 /* Bottom.swift */; };
 		D42F483827FED4C9009FECA0 /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42F483727FED4C9009FECA0 /* CategoryView.swift */; };
 		E901BB9528006550003AF610 /* HonorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901BB9428006550003AF610 /* HonorView.swift */; };
@@ -33,7 +33,7 @@
 		7953083227FD7E79000D40DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7953083527FD7E79000D40DB /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		BF2CEDF928006ECB003401D6 /* GuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideView.swift; sourceTree = "<group>"; };
-		BF2CEDFB28006F08003401D6 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		BF2CEDFB28006F08003401D6 /* GuideImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideImageView.swift; sourceTree = "<group>"; };
 		BF2CEDFF28006FB1003401D6 /* Bottom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bottom.swift; sourceTree = "<group>"; };
 		D42F483727FED4C9009FECA0 /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
 		E901BB9428006550003AF610 /* HonorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HonorView.swift; sourceTree = "<group>"; };
@@ -77,7 +77,7 @@
 				552605BB27FED8EE0028C141 /* CategoryRow.swift */,
 				D42F483727FED4C9009FECA0 /* CategoryView.swift */,
 				BF2CEDF928006ECB003401D6 /* GuideView.swift */,
-				BF2CEDFB28006F08003401D6 /* ImageView.swift */,
+				BF2CEDFB28006F08003401D6 /* GuideImageView.swift */,
 				BF2CEDFF28006FB1003401D6 /* Bottom.swift */,
 				79373AFE28006D7400CDAD04 /* ClearView.swift */,
 				E901BB9428006550003AF610 /* HonorView.swift */,
@@ -167,7 +167,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF2CEDFC28006F08003401D6 /* ImageView.swift in Sources */,
+				BF2CEDFC28006F08003401D6 /* GuideImageView.swift in Sources */,
 				D42F483827FED4C9009FECA0 /* CategoryView.swift in Sources */,
 				79373AFF28006D7400CDAD04 /* ClearView.swift in Sources */,
 				552605BC27FED8EE0028C141 /* CategoryRow.swift in Sources */,

--- a/Noo6Main/CategoryList.swift
+++ b/Noo6Main/CategoryList.swift
@@ -15,7 +15,7 @@ struct CategoryList: View {
                 ZStack {
                     CategoryRow(guideInfo: info)
                         .listRowBackground(Color.white)
-                    NavigationLink(destination: Text("\(info.guideName)의 CategoryView")) {}
+                    NavigationLink(destination: CategoryView(guideName: info.guideName)) {}
                         .frame(width: 0)   // NavigationLink 화살표 제거를 위함 1
                         .opacity(0)        // NavigationLink 화살표 제거를 위함 1
                 }

--- a/Noo6Main/CategoryList.swift
+++ b/Noo6Main/CategoryList.swift
@@ -15,7 +15,7 @@ struct CategoryList: View {
                 ZStack {
                     CategoryRow(guideInfo: info)
                         .listRowBackground(Color.white)
-                    NavigationLink(destination: Text("\(info.description)의 CategoryView")) {}
+                    NavigationLink(destination: Text("\(info.guideName)의 CategoryView")) {}
                         .frame(width: 0)   // NavigationLink 화살표 제거를 위함 1
                         .opacity(0)        // NavigationLink 화살표 제거를 위함 1
                 }
@@ -32,7 +32,7 @@ struct CategoryList: View {
 // 임시 가이드 정보 struct
 struct GuideInfo: Identifiable {
     let id = UUID()
-    let description: String
+    let guideName: String
     let largeTitle: String
     let compledtedNumber: Int
     let allNumber: Int
@@ -41,13 +41,13 @@ struct GuideInfo: Identifiable {
 
 // 임의 가이드 정보 struct test array
 let guideInfos = [
-    GuideInfo(description: "아이폰 초보자 가이드", largeTitle: "아이폰이 처음이신가요?", compledtedNumber: 4, allNumber: 4, isAllCleared: true),
-    GuideInfo(description: "알면 유용한 기능", largeTitle: "알림을 없애볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
-    GuideInfo(description: "캘린더", largeTitle: "일정을 관리해볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
-    GuideInfo(description: "사진", largeTitle: "사진을 편집해볼까요?", compledtedNumber: 1, allNumber: 4, isAllCleared: false),
-    GuideInfo(description: "건강", largeTitle: "건강 데이터를 확인할까요?", compledtedNumber: 4, allNumber: 4, isAllCleared: true),
-    GuideInfo(description: "카메라", largeTitle: "다양한 사진을 찍어볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
-    GuideInfo(description: "메모", largeTitle: "메모장이 필요하신가요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false)
+    GuideInfo(guideName: "아이폰 초보자 가이드", largeTitle: "아이폰이 처음이신가요?", compledtedNumber: 4, allNumber: 4, isAllCleared: true),
+    GuideInfo(guideName: "알면 유용한 기능", largeTitle: "알림을 없애볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
+    GuideInfo(guideName: "캘린더", largeTitle: "일정을 관리해볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
+    GuideInfo(guideName: "사진", largeTitle: "사진을 편집해볼까요?", compledtedNumber: 1, allNumber: 4, isAllCleared: false),
+    GuideInfo(guideName: "건강", largeTitle: "건강 데이터를 확인할까요?", compledtedNumber: 4, allNumber: 4, isAllCleared: true),
+    GuideInfo(guideName: "카메라", largeTitle: "다양한 사진을 찍어볼까요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false),
+    GuideInfo(guideName: "메모", largeTitle: "메모장이 필요하신가요?", compledtedNumber: 0, allNumber: 4, isAllCleared: false)
 ]
 
 struct CategoryList_Previews: PreviewProvider {

--- a/Noo6Main/CategoryRow.swift
+++ b/Noo6Main/CategoryRow.swift
@@ -19,7 +19,7 @@ struct CategoryRow: View {
                 .cornerRadius(15)
             VStack(alignment: .leading, spacing: 10.0) {
                 HStack {
-                    Text("\(guideInfo.description) (\(guideInfo.compledtedNumber)/\(guideInfo.allNumber))")
+                    Text("\(guideInfo.guideName) (\(guideInfo.compledtedNumber)/\(guideInfo.allNumber))")
                     // 가이드를 모두 완료했을 경우 왕관 이미지 생성됨
                     if guideInfo.isAllCleared {
                         Image(systemName: "crown")

--- a/Noo6Main/CategoryView.swift
+++ b/Noo6Main/CategoryView.swift
@@ -13,7 +13,6 @@ struct CategoryView : View {
 
     var body: some View{
         VStack {
-            NavigationView{
                 VStack{
                     // 임시 안내 문구 삽입 -> 데이터 받아온 후 데이터에 맞는 문구로 수정 필요
                     Text("\(guideName)에서 \n어떤 가이드를 받아 볼까요?")
@@ -26,7 +25,7 @@ struct CategoryView : View {
                     List(contentInfos, id: \.id) {
                         info in
                         // 버튼 누를 시 임시로 EmptyView로 이동 -> merge 후 가이드뷰로 이동하도록 수정 필요
-                        NavigationLink(destination: EmptyView()){
+                        NavigationLink(destination: GuideView()){
                             ContentList(contentInfo: info)
                                 .listRowBackground(Color.white)
                                 .listRowSeparator(.hidden)
@@ -39,8 +38,6 @@ struct CategoryView : View {
                     
                     Spacer() // 화면 상단에 List를 보여주기 위해 공백 삽입
                 }
-                
-            }
             
         }.padding([.leading, .trailing], 16)
     }

--- a/Noo6Main/CategoryView.swift
+++ b/Noo6Main/CategoryView.swift
@@ -9,13 +9,14 @@ import Foundation
 import SwiftUI
 
 struct CategoryView : View {
+    var guideName: String
 
     var body: some View{
         VStack {
             NavigationView{
                 VStack{
                     // 임시 안내 문구 삽입 -> 데이터 받아온 후 데이터에 맞는 문구로 수정 필요
-                    Text("아이폰 초보자 가이드에서 \n어떤 가이드를 받아 볼까요?")
+                    Text("\(guideName)에서 \n어떤 가이드를 받아 볼까요?")
                         .frame(width: 342)
                         .font(.system(size: 30))
                         .padding(.bottom, 40)
@@ -90,6 +91,6 @@ struct ContentList : View {
 
 struct CategoryView_Previews: PreviewProvider {
     static var previews: some View {
-        CategoryView()
+        CategoryView(guideName: "아이폰 초보자 가이드")
     }
 }

--- a/Noo6Main/ClearView.swift
+++ b/Noo6Main/ClearView.swift
@@ -33,7 +33,7 @@ struct ClearView: View {
             Button(action: {
                 print("가이드 카테고리로 갑니다.")
             }, label: {
-                NavigationLink(destination: CategoryView()){
+                NavigationLink(destination: CategoryView(guideName: "아이폰 초보자 가이드")){
                     Text("다른 가이드 배우기")
                         .foregroundColor(Color.white)
                 }

--- a/Noo6Main/GuideImageView.swift
+++ b/Noo6Main/GuideImageView.swift
@@ -46,6 +46,6 @@ let guidelists = [
 ]
 struct ImageView_Previews: PreviewProvider {
     static var previews: some View {
-        ImageView()
+        GuideImageView()
     }
 }

--- a/Noo6Main/GuideView.swift
+++ b/Noo6Main/GuideView.swift
@@ -13,7 +13,7 @@ struct GuideView: View {
             
             VStack{
                 
-                ImageView()
+                GuideImageView()
                 Bottom()
                 NavigationLink(destination: EmptyView()){//가이끝 뷰로 넘기기
                     //Text("맨 마지막에서 버튼")

--- a/Noo6Main/HomeView.swift
+++ b/Noo6Main/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
             .navigationBarItems(
                 trailing:
                     NavigationLink(
-                        destination:HonorView(),
+                        destination: HonorView(),
                         label:{
                             Image(systemName: "archivebox")
                                 .resizable()
@@ -43,11 +43,5 @@ struct HomeView: View {
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView()
-    }
-}
-
-struct HonorView: View {
-    var body: some View {
-       Text("HonorView")
     }
 }

--- a/Noo6Main/HonorDetailView.swift
+++ b/Noo6Main/HonorDetailView.swift
@@ -15,7 +15,7 @@ struct HonorDetailView: View {
                 Text("당신은 사진찍기 전문가!")
                 .font(.largeTitle)
                 .fontWeight(.semibold)
-        ImageView()
+        HonorImageView()
         Text("어쩌구 저쩌구 설명 설명")
             .padding()
             .font(.system(size: 20))
@@ -28,7 +28,7 @@ struct HonorDetailView: View {
 
 
 //짤이 들어갈 이미지 뷰입니다
-struct ImageView: View {
+struct HonorImageView: View {
     var body: some View {
         Image("Test")
             .resizable()

--- a/Noo6Main/HonorView.swift
+++ b/Noo6Main/HonorView.swift
@@ -15,7 +15,7 @@ let honorMemo = 0
 
 
 
-struct honorView: View {
+struct HonorView: View {
     var body: some View {
         VStack {
         ScrollView {
@@ -98,6 +98,6 @@ struct honorView: View {
 
 struct honorView_Previews: PreviewProvider {
     static var previews: some View {
-        honorView()
+        HonorView()
     }
 }

--- a/Noo6Main/ImageView.swift
+++ b/Noo6Main/ImageView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ImageView: View {
+struct GuideImageView: View {
     @State var currentPage: Int = 0
     var body: some View {
         VStack {


### PR DESCRIPTION

https://user-images.githubusercontent.com/83946704/162482422-ce8607bd-b15e-4d63-8145-a768b9f57646.mp4

구현사항
1. 각 View 사이의 NavigationLink 연결 (GuideView -> ClearView, HonorView -> HonorDetailView 제외)
(제외한 View들은 현재 상위 View에 존재하는 버튼에서 NavigationLink가 구현이 완료되지 않아 제외하였습니다.)

오류해결사항
1. Ocean의 ImageView 구조체와 Sasha의 ImageView 구조체 간 같은 구조체명으로 오류가 생겨 각각 GuideImageView, HonorImageView로 수정하였습니다.
2. Ocean의 ImageView.swift 파일명을 GuideImageView.swift로 변경하였습니다.
3. Mincho의 HonorView.swift 내의 honorView 구조체의 구조체 명을 HonorView로 변경하였습니다.
4. Rang의 CategoryView에서 GuideView로 이동할 때 상단의 NavigationBar가 중첩으로 생기는 오류가 있어 CategoryView의 NavigationView를 제거하였습니다.